### PR TITLE
fixed: eslint woes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -50,7 +50,7 @@
     "no-dupe-keys": 2, // disallow duplicate keys when creating object literals
     "no-duplicate-case": 2, // disallow a duplicate case label.
     "no-empty": 2, // disallow empty statements
-    "no-empty-class": 2, // disallow the use of empty character classes in regular expressions
+    "no-empty-character-class": 2, // disallow the use of empty character classes in regular expressions
     "no-ex-assign": 2, // disallow assigning to the exception in a catch block
     "no-extra-boolean-cast": 2, // disallow double-negation boolean casts in a boolean context
     "no-extra-parens": 0, // disallow unnecessary parentheses
@@ -270,6 +270,7 @@
     "react/wrap-multilines": 2, // Prevent missing parentheses around multilines JSX
     "react/sort-comp": [1, { // Enforce component methods order
         "order": [
+            "attemptedTransition",
             "lifecycle",
             "/Transition/",
             "/^(handle|on).+$/",

--- a/app/stores/auth.js
+++ b/app/stores/auth.js
@@ -25,9 +25,9 @@ function _postAndHandleParseUser(url, username, password, done) {
     .end(function(err, res) {
       if (!err && res.body && res.body.user) {
         _user = parseUser(res.body.user);
-        /* eslint-disable block-scoped-var */
+        /* eslint-disable no-use-before-define */
         AuthStore.notifyChange();
-        /* eslint-enable block-scoped-var */
+        /* eslint-enable no-use-before-define */
       }
       if (done) {
         done(err, _user);


### PR DESCRIPTION
some linting issues have been fixed in this commit:

- error Rule 'no-empty-class' was removed and replaced by: no-empty-character-class  no-empty-class
- warning attemptedTransition must be placed before displayName  react/sort-comp
- error  AuthStore was used before it was defined  no-use-before-define