### PR TITLE
Use arrow function in webpack.config.js w/o curly braces

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -85,7 +85,5 @@ export default (options) => {
     },
   };
 
-  return strategies.reduce((conf, strategy) => {
-    return strategy(conf, options);
-  }, config);
+  return strategies.reduce((conf, strategy) => strategy(conf, options), config);
 };


### PR DESCRIPTION
Use arrow function w/o curly braces.
